### PR TITLE
Fix: Update GitHub Actions workflow versions to v4 (fixes #19)

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
       - name: Install dependencies


### PR DESCRIPTION
Fixes #19

Updates outdated GitHub Actions versions in `.github/workflows/releases.yml`:

- `actions/checkout@v2/v3` → `actions/checkout@v4`
- `actions/setup-node@v2/v3` → `actions/setup-node@v4`

This ensures we're using the latest stable versions of these actions.